### PR TITLE
k8s-mixed-worker-node readiness probe #402

### DIFF
--- a/k8s-mixed-worker-nodes/.gitignore
+++ b/k8s-mixed-worker-nodes/.gitignore
@@ -1,1 +1,2 @@
 .terraform
+.tmp

--- a/k8s-mixed-worker-nodes/Makefile
+++ b/k8s-mixed-worker-nodes/Makefile
@@ -2,16 +2,20 @@
 
 export AWS_DEFAULT_REGION      ?= us-east-2
 
-terraform   ?= terraform-v0.12
-jq := jq -cRM
+terraform			?= terraform-v0.12
+jq 					:= jq -cM
+aws					?= aws
+TMP					:= $(abspath .tmp)
+WAIT_TIMEOUT		:= 1800
+MIN_NUMB_NODES		?= 1
 
 export TF_VAR_name             ?= $(error undefined env var TF_VAR_name)
 export TF_VAR_s3_bucket        ?= $(error undefined env var TF_VAR_s3_bucket)
 export TF_VAR_s3_bucket_region ?= $(error undefined env var TF_VAR_s3_bucket_region)
 export TF_VAR_domain_name      ?= $(error undefined env var TF_VAR_domain_name)
-export TF_VAR_subnet_ids       := $(shell echo '$(sort $(SUBNET_ID) $(SUBNET_IDS))' | tr ',' ' ' | xargs | $(jq) 'split(" ")')
-export TF_VAR_sg_ids           := $(shell echo '$(SG_IDS)' | tr ',' ' ' | xargs | $(jq) 'split(" ")')
-export TF_VAR_instance_size    := $(shell echo '$(INSTANCE_SIZE)' | tr ',' ' ' | xargs | $(jq) 'split(" ")')
+export TF_VAR_subnet_ids       := $(shell echo '$(sort $(SUBNET_ID) $(SUBNET_IDS))' | tr ',' ' ' | xargs | $(jq) -R  'split(" ")')
+export TF_VAR_sg_ids           := $(shell echo '$(SG_IDS)' | tr ',' ' ' | xargs | $(jq) -R 'split(" ")')
+export TF_VAR_instance_size    := $(shell echo '$(INSTANCE_SIZE)' | tr ',' ' ' | xargs | $(jq) -R 'split(" ")')
 export TF_VAR_cluster_tag      := $(shell echo $(TF_VAR_domain_name) | sed -e s/\\./-/)
 
 export TF_DATA_DIR ?= .terraform/$(TF_VAR_name)
@@ -22,6 +26,7 @@ TF_CLI_ARGS ?= -no-color -input=false
 TFPLAN      := $(TF_DATA_DIR)/terraform.tfplan
 
 VALID_NAME   = $(shell echo $(TF_VAR_name) | grep -Eq ^$(SHORT_NAME) && echo matched)
+
 
 ifneq ($(VALID_NAME),matched)
 $(error "shortName" parameter must be a prefix to "name" parameter $(TF_VAR_name))
@@ -34,8 +39,9 @@ deploy: init import plan
 		$(MAKE) import plan apply || \
 		$(MAKE) import plan apply
 	$(MAKE) kubernetes/nvidia-gpu-device-plugin.yml
+	$(MAKE) wait
 
-$(TF_DATA_DIR):
+$(TF_DATA_DIR) $(TMP):
 	@rm -rf $@ && mkdir -p $@
 
 init: $(TF_DATA_DIR)
@@ -74,3 +80,46 @@ import:
 -include ../Mk/phonies
 
 .PHONY: kubernetes/nvidia-gpu-device-plugin.yml
+
+wait: $(TMP)
+	$(eval current_time := date +%s)
+
+	$(eval autoscaling_group_name := $(shell $(terraform) output autoscaling_group_name))
+	$(eval jq_group_node_ids := $(jq) -r '.AutoScalingGroups[0].Instances[].InstanceId')
+
+	$(eval resolve_aws_node_ids := $(aws) autoscaling describe-auto-scaling-groups --auto-scaling-group-names  $(autoscaling_group_name) \
+			| $(jq_group_node_ids) | xargs)
+
+	$(eval jq_status_nodes_expr := 'select(.status.conditions[] | .type == "Ready" and .status == $$$$readyStatus) | .metadata.name')
+
+	$(eval jq_group_node_names := $(jq) '.items[] | select( .spec.providerID | split("/") | last | IN($$$$ARGS.positional[]))')
+
+	@ echo "Waiting for cluster nodes within $(autoscaling_group_name) to boot"
+
+	$(eval timeout := $(shell echo "`$(current_time)` + $(WAIT_TIMEOUT)" | bc ))
+
+	@ while [ `$(current_time)` -le "$(timeout)" ]; do \
+		aws_node_ids="`$(resolve_aws_node_ids)`"; \
+		nodes_json="$(TMP)/debug-`$(current_time)`.json"; \
+		$(kubectl) get nodes -o json > $$nodes_json; \
+		asg_group_nodes="`$(jq_group_node_names) --args $$aws_node_ids < $$nodes_json`"; \
+		ready="`echo $$asg_group_nodes | $(jq) -r --arg  readyStatus True $(jq_status_nodes_expr) | xargs`"; \
+		not_ready="`echo $$asg_group_nodes | $(jq) -r --arg  readyStatus False $(jq_status_nodes_expr) | xargs`"; \
+		test -n "$$ready" && \
+			echo "Ready nodes [$$ready] expecting at least $(MIN_NUMB_NODES)";\
+		test -n "$$not_ready" && \
+			echo "Not ready nodes [$$not_ready]";\
+		ready_count="`echo $$ready | wc -w | xargs`"; \
+		not_ready_count="`echo $$not_ready | wc -w | xargs`"; \
+		up_count="`echo $$ready_count + $$not_ready_count | bc`"; \
+		if [ "$$ready_count" -ge '$(MIN_NUMB_NODES)' ]; then \
+			echo "Succeeded (ready: $$ready_count; expecting at least: $(MIN_NUMB_NODES))"; \
+			exit 0; \
+		fi; \
+		echo "Still waiting (nodes up: $$up_count; ready: $$ready_count; expecting at least: $(MIN_NUMB_NODES))..."; \
+		sleep 8; \
+	done; \
+	echo "ERROR timeout $(WAIT_TIMEOUT)sec"; \
+	exit 1;
+
+	@ echo "-- Workers group is ready --"

--- a/k8s-mixed-worker-nodes/outputs.tf
+++ b/k8s-mixed-worker-nodes/outputs.tf
@@ -5,3 +5,7 @@ output "bootstrap_script" {
 output "bootstrap_script_s3" {
   value = "s3://${aws_s3_bucket_object.bootstrap_script.bucket}/${aws_s3_bucket_object.bootstrap_script.key}"
 }
+
+output "autoscaling_group_name" {
+  value = aws_autoscaling_group.workers.name
+}


### PR DESCRIPTION
Actually this almost repeats the previous `stack-k8s` implementation with the only difference it cares the own ASG nodes only.