### PR TITLE
Gitlab helm3

### DIFF
--- a/gitlab-cn/hub-component.yaml
+++ b/gitlab-cn/hub-component.yaml
@@ -20,8 +20,8 @@ requires:
   - gcp
   - kubernetes
   - helm
-  - tiller
   - cert-manager
+  - external-dns
   - bucket
 
 provides:


### PR DESCRIPTION
Notable changes: 

Gitlab : 

- Uses Helm3 
- Will use `component.bucket.endpoint.internal` if it exists and prefer it over `component.bucket.endpoint` as the perfomance is much better 
- When installing gitlab we now use `upgrade --install` approach instead of the `check + install --replace`.   This helm chart has a stable  and automatic upgrade process.  
- Removes all DNS provisioning scripts for all platforms
- Removes all StorageClass resources, as those are provided by our default StorageClass convention. 
- Unique naming (using stack name) for all gitlab resources (including namespace) - all helper scripts respect this. 
- Removed *all* references to minio.  It now only depends on `bucket` and `component.bucket.*` 


Minio: 

- Now checks to see if the NATS event registration is present before trying to register it again (fixes #389 )


Cert-Manager: 

*  Now outputs issuer-related details so that gitlab can annotate correctly. 

s3-bucket: 

- Changes provides: `s3-bucket`  to `bucket` 