### PR TITLE
Trim password db params

### DIFF
--- a/dex/kubernetes/configmap.yaml.gotemplate
+++ b/dex/kubernetes/configmap.yaml.gotemplate
@@ -31,7 +31,7 @@ data:
         GetUserInfo: true
         insecureSkipEmailVerified: true
 {{end}}
-{{if and .component.dex.passwordDb.email .component.dex.passwordDb.password}}
+{{if and (.component.dex.passwordDb.email | trim) (.component.dex.passwordDb.password | trim)}}
     enablePasswordDB: true
     staticPasswords:
     - email: '{{.component.dex.passwordDb.email}}'


### PR DESCRIPTION
This change is based on the case when dex was deployed with a configuration of password DB. Later OKTA or some other connector was configured, and the User wants to disable login via password DB. In this case, pass empty (" ") params will still enable these connector. To solve this, I propose to `trim` fields in the dex config template.